### PR TITLE
migrating F* to ppxlib: refreshing some snapshots

### DIFF
--- a/src/parser/parse.fsy
+++ b/src/parser/parse.fsy
@@ -914,10 +914,7 @@ subEffect:
 | quident SQUIGGLY_RARROW quident LBRACE IDENT EQUALS simpleTerm RBRACE
     {let (src_eff, _2, tgt_eff, _4, x, _2_inlined1, y, _7) = ($1, (), $3, (), $5, (), $7, ()) in
 let lift2_opt =     ( None ) in
-let lift1 =
-  let _2 = _2_inlined1 in
-      ( (x, y) )
-in
+let lift1 =     ( (x, y) ) in
      (
        match lift2_opt with
        | None ->
@@ -941,17 +938,14 @@ in
 | quident SQUIGGLY_RARROW quident LBRACE IDENT EQUALS simpleTerm SEMICOLON IDENT EQUALS simpleTerm RBRACE
     {let (src_eff, _2, tgt_eff, _4, x, _2_inlined1, y, _1, id, _2_inlined2, y_inlined1, _7) = ($1, (), $3, (), $5, (), $7, (), $9, (), $11, ()) in
 let lift2_opt =
-  let (y, _2) = (y_inlined1, _2_inlined2) in
+  let y = y_inlined1 in
   let x =
     let x =                                                           (id) in
         ( (x, y) )
   in
       ( Some x )
 in
-let lift1 =
-  let _2 = _2_inlined1 in
-      ( (x, y) )
-in
+let lift1 =     ( (x, y) ) in
      (
        match lift2_opt with
        | None ->
@@ -1399,10 +1393,7 @@ noSeqTerm:
       ( mk_term (Ascribed(e,{t with level=Expr},tactic_opt)) (rhs2 parseState 1 4) Expr )}
 | atomicTermNotQUident DOT_LPAREN term RPAREN LARROW noSeqTerm
     {let (e1, _1, e, _3_inlined1, _3, e3) = ($1, (), $3, (), (), $6) in
-let op_expr =
-  let _3 = _3_inlined1 in
-                               ( mk_ident (".()", rhs parseState 1), e, rhs2 parseState 1 3 )
-in
+let op_expr =                              ( mk_ident (".()", rhs parseState 1), e, rhs2 parseState 1 3 ) in
       (
         let (op, e2, _) = op_expr in
         let opid = mk_ident (string_of_id op ^ "<-", range_of_id op) in
@@ -1410,10 +1401,7 @@ in
       )}
 | atomicTermNotQUident DOT_LBRACK term RBRACK LARROW noSeqTerm
     {let (e1, _1, e, _3_inlined1, _3, e3) = ($1, (), $3, (), (), $6) in
-let op_expr =
-  let _3 = _3_inlined1 in
-                               ( mk_ident (".[]", rhs parseState 1), e, rhs2 parseState 1 3 )
-in
+let op_expr =                              ( mk_ident (".[]", rhs parseState 1), e, rhs2 parseState 1 3 ) in
       (
         let (op, e2, _) = op_expr in
         let opid = mk_ident (string_of_id op ^ "<-", range_of_id op) in
@@ -1421,10 +1409,7 @@ in
       )}
 | atomicTermNotQUident DOT_LBRACK_BAR term BAR_RBRACK LARROW noSeqTerm
     {let (e1, _1, e, _3_inlined1, _3, e3) = ($1, (), $3, (), (), $6) in
-let op_expr =
-  let _3 = _3_inlined1 in
-                                       ( mk_ident (".[||]", rhs parseState 1), e, rhs2 parseState 1 3 )
-in
+let op_expr =                                      ( mk_ident (".[||]", rhs parseState 1), e, rhs2 parseState 1 3 ) in
       (
         let (op, e2, _) = op_expr in
         let opid = mk_ident (string_of_id op ^ "<-", range_of_id op) in
@@ -1432,10 +1417,7 @@ in
       )}
 | atomicTermNotQUident DOT_LENS_PAREN_LEFT term LENS_PAREN_RIGHT LARROW noSeqTerm
     {let (e1, _1, e, _3_inlined1, _3, e3) = ($1, (), $3, (), (), $6) in
-let op_expr =
-  let _3 = _3_inlined1 in
-                                                  ( mk_ident (".(||)", rhs parseState 1), e, rhs2 parseState 1 3 )
-in
+let op_expr =                                                 ( mk_ident (".(||)", rhs parseState 1), e, rhs2 parseState 1 3 ) in
       (
         let (op, e2, _) = op_expr in
         let opid = mk_ident (string_of_id op ^ "<-", range_of_id op) in

--- a/tests/interactive/backtracking.refinements.out.expected
+++ b/tests/interactive/backtracking.refinements.out.expected
@@ -1,7 +1,7 @@
 {"kind": "protocol-info", "rest": "[...]"}
 {"kind": "response", "query-id": "1", "response": [], "status": "success"}
 {"kind": "response", "query-id": "2", "response": [], "status": "success"}
-{"kind": "response", "query-id": "3", "response": [{"level": "error", "message": "Syntax error: Stdlib.Parsing.Parse_error", "number": 168, "ranges": [{"beg": [3, 6], "end": [3, 6], "fname": "<input>"}]}], "status": "success"}
+{"kind": "response", "query-id": "3", "response": [{"level": "error", "message": "Syntax error: Parsing.Parse_error", "number": 168, "ranges": [{"beg": [3, 6], "end": [3, 6], "fname": "<input>"}]}], "status": "success"}
 {"kind": "response", "query-id": "4", "response": [], "status": "success"}
 {"kind": "response", "query-id": "5", "response": [], "status": "success"}
 {"kind": "response", "query-id": "6", "response": [], "status": "success"}
@@ -10,11 +10,11 @@
 {"kind": "response", "query-id": "9", "response": [], "status": "success"}
 {"kind": "response", "query-id": "10", "response": [], "status": "success"}
 {"kind": "response", "query-id": "11", "response": null, "status": "success"}
-{"kind": "response", "query-id": "12", "response": [{"level": "error", "message": "Syntax error: Stdlib.Parsing.Parse_error", "number": 168, "ranges": [{"beg": [3, 12], "end": [3, 12], "fname": "<input>"}]}], "status": "success"}
-{"kind": "response", "query-id": "13", "response": [{"level": "error", "message": "Syntax error: Stdlib.Parsing.Parse_error", "number": 168, "ranges": [{"beg": [3, 12], "end": [3, 12], "fname": "<input>"}]}], "status": "success"}
-{"kind": "response", "query-id": "14", "response": [{"level": "error", "message": "Syntax error: Stdlib.Parsing.Parse_error", "number": 168, "ranges": [{"beg": [3, 12], "end": [3, 12], "fname": "<input>"}]}], "status": "success"}
-{"kind": "response", "query-id": "15", "response": [{"level": "error", "message": "Syntax error: Stdlib.Parsing.Parse_error", "number": 168, "ranges": [{"beg": [3, 12], "end": [3, 12], "fname": "<input>"}]}], "status": "success"}
-{"kind": "response", "query-id": "16", "response": [{"level": "error", "message": "Syntax error: Stdlib.Parsing.Parse_error", "number": 168, "ranges": [{"beg": [3, 12], "end": [3, 12], "fname": "<input>"}]}], "status": "success"}
+{"kind": "response", "query-id": "12", "response": [{"level": "error", "message": "Syntax error: Parsing.Parse_error", "number": 168, "ranges": [{"beg": [3, 12], "end": [3, 12], "fname": "<input>"}]}], "status": "success"}
+{"kind": "response", "query-id": "13", "response": [{"level": "error", "message": "Syntax error: Parsing.Parse_error", "number": 168, "ranges": [{"beg": [3, 12], "end": [3, 12], "fname": "<input>"}]}], "status": "success"}
+{"kind": "response", "query-id": "14", "response": [{"level": "error", "message": "Syntax error: Parsing.Parse_error", "number": 168, "ranges": [{"beg": [3, 12], "end": [3, 12], "fname": "<input>"}]}], "status": "success"}
+{"kind": "response", "query-id": "15", "response": [{"level": "error", "message": "Syntax error: Parsing.Parse_error", "number": 168, "ranges": [{"beg": [3, 12], "end": [3, 12], "fname": "<input>"}]}], "status": "success"}
+{"kind": "response", "query-id": "16", "response": [{"level": "error", "message": "Syntax error: Parsing.Parse_error", "number": 168, "ranges": [{"beg": [3, 12], "end": [3, 12], "fname": "<input>"}]}], "status": "success"}
 {"kind": "response", "query-id": "17", "response": [], "status": "success"}
 {"kind": "response", "query-id": "18", "response": [{"level": "error", "message": "Subtyping check failed; expected type a: nat{a > 2}; got type int; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel", "number": 19, "ranges": [{"beg": [3, 23], "end": [3, 24], "fname": "<input>"}, {"beg": [3, 14], "end": [3, 19], "fname": "<input>"}]}], "status": "failure"}
 {"kind": "response", "query-id": "19", "response": [], "status": "success"}
@@ -29,17 +29,17 @@
 {"kind": "response", "query-id": "28", "response": [], "status": "success"}
 {"kind": "response", "query-id": "29", "response": [], "status": "success"}
 {"kind": "response", "query-id": "30", "response": [], "status": "success"}
-{"kind": "response", "query-id": "31", "response": [{"level": "error", "message": "Syntax error: Stdlib.Parsing.Parse_error", "number": 168, "ranges": [{"beg": [5, 5], "end": [5, 5], "fname": "<input>"}]}], "status": "success"}
-{"kind": "response", "query-id": "32", "response": [{"level": "error", "message": "Syntax error: Stdlib.Parsing.Parse_error", "number": 168, "ranges": [{"beg": [5, 8], "end": [5, 8], "fname": "<input>"}]}], "status": "success"}
+{"kind": "response", "query-id": "31", "response": [{"level": "error", "message": "Syntax error: Parsing.Parse_error", "number": 168, "ranges": [{"beg": [5, 5], "end": [5, 5], "fname": "<input>"}]}], "status": "success"}
+{"kind": "response", "query-id": "32", "response": [{"level": "error", "message": "Syntax error: Parsing.Parse_error", "number": 168, "ranges": [{"beg": [5, 8], "end": [5, 8], "fname": "<input>"}]}], "status": "success"}
 {"kind": "response", "query-id": "33", "response": [], "status": "success"}
 {"kind": "response", "query-id": "34", "response": [], "status": "success"}
 {"kind": "response", "query-id": "35", "response": [{"level": "error", "message": "Identifier not found: [b]", "number": 72, "ranges": [{"beg": [5, 7], "end": [5, 8], "fname": "<input>"}]}], "status": "success"}
 {"kind": "response", "query-id": "36", "response": [{"level": "error", "message": "Identifier not found: [b]", "number": 72, "ranges": [{"beg": [5, 7], "end": [5, 8], "fname": "<input>"}]}], "status": "success"}
 {"kind": "response", "query-id": "37", "response": [[3, "Prims", "nat"]], "status": "success"}
 {"kind": "response", "query-id": "38", "response": [], "status": "success"}
-{"kind": "response", "query-id": "39", "response": [{"level": "error", "message": "Syntax error: Stdlib.Parsing.Parse_error", "number": 168, "ranges": [{"beg": [5, 15], "end": [5, 15], "fname": "<input>"}]}], "status": "success"}
-{"kind": "response", "query-id": "40", "response": [{"level": "error", "message": "Syntax error: Stdlib.Parsing.Parse_error", "number": 168, "ranges": [{"beg": [5, 19], "end": [5, 19], "fname": "<input>"}]}], "status": "success"}
-{"kind": "response", "query-id": "41", "response": [{"level": "error", "message": "Syntax error: Stdlib.Parsing.Parse_error", "number": 168, "ranges": [{"beg": [5, 26], "end": [5, 26], "fname": "<input>"}]}], "status": "success"}
+{"kind": "response", "query-id": "39", "response": [{"level": "error", "message": "Syntax error: Parsing.Parse_error", "number": 168, "ranges": [{"beg": [5, 15], "end": [5, 15], "fname": "<input>"}]}], "status": "success"}
+{"kind": "response", "query-id": "40", "response": [{"level": "error", "message": "Syntax error: Parsing.Parse_error", "number": 168, "ranges": [{"beg": [5, 19], "end": [5, 19], "fname": "<input>"}]}], "status": "success"}
+{"kind": "response", "query-id": "41", "response": [{"level": "error", "message": "Syntax error: Parsing.Parse_error", "number": 168, "ranges": [{"beg": [5, 26], "end": [5, 26], "fname": "<input>"}]}], "status": "success"}
 {"kind": "response", "query-id": "42", "response": [], "status": "success"}
 {"kind": "response", "query-id": "43", "response": [], "status": "success"}
 {"kind": "response", "query-id": "44", "response": [], "status": "success"}

--- a/tests/interactive/integration.push-pop.out.expected
+++ b/tests/interactive/integration.push-pop.out.expected
@@ -76,7 +76,7 @@
 {"kind": "response", "query-id": "75", "response": [], "status": "success"}
 {"kind": "response", "query-id": "79", "response": [], "status": "success"}
 {"kind": "response", "query-id": "80", "response": [], "status": "success"}
-{"kind": "response", "query-id": "91", "response": [{"level": "error", "message": "Syntax error: Stdlib.Parsing.Parse_error", "number": 168, "ranges": [{"beg": [12, 0], "end": [12, 0], "fname": "<input>"}]}], "status": "success"}
+{"kind": "response", "query-id": "91", "response": [{"level": "error", "message": "Syntax error: Parsing.Parse_error", "number": 168, "ranges": [{"beg": [12, 0], "end": [12, 0], "fname": "<input>"}]}], "status": "success"}
 {"kind": "response", "query-id": "98", "response": [], "status": "success"}
 {"kind": "response", "query-id": "101", "response": [{"level": "error", "message": "Subtyping check failed; expected type nat; got type int; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel", "number": 19, "ranges": [{"beg": [11, 15], "end": [11, 17], "fname": "<input>"}, {"beg": [626, 18], "end": [626, 24], "fname": "prims.fst"}]}], "status": "failure"}
 {"kind": "response", "query-id": "107", "response": [], "status": "success"}
@@ -92,7 +92,7 @@
 {"kind": "response", "query-id": "128", "response": [], "status": "success"}
 {"kind": "response", "query-id": "130", "response": [], "status": "success"}
 {"kind": "response", "query-id": "133", "response": [], "status": "success"}
-{"kind": "response", "query-id": "137", "response": [{"level": "error", "message": "Syntax error: Stdlib.Parsing.Parse_error", "number": 168, "ranges": [{"beg": [13, 4], "end": [13, 4], "fname": "<input>"}]}], "status": "success"}
+{"kind": "response", "query-id": "137", "response": [{"level": "error", "message": "Syntax error: Parsing.Parse_error", "number": 168, "ranges": [{"beg": [13, 4], "end": [13, 4], "fname": "<input>"}]}], "status": "success"}
 {"kind": "response", "query-id": "159", "response": [{"level": "error", "message": "Expected expression of type \"Type0\"; got expression \"Integration.xx\" of type \"nat\"", "number": 189, "ranges": [{"beg": [13, 15], "end": [13, 20], "fname": "<input>"}]}], "status": "success"}
 {"kind": "response", "query-id": "163", "response": [], "status": "success"}
 {"kind": "response", "query-id": "164", "response": [], "status": "success"}


### PR DESCRIPTION
This PR solves 2 issues due to printing differences introduced by ppxlib 0.22:
* it updates the F* OCaml snapshot, in particular the parser
* it updates some test output snapshots

In particular, without the latter change, `make -C src uregressions` fails. This PR makes it succeed.

This PR is not related to CI infrastructure.